### PR TITLE
Add unit-based multi site management

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -59,7 +59,7 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		gm[g.ID] = g.ToListItem()
 	}
 
-	token, _ := utils.GenerateJWT(user.ID.Hex())
+        token, _ := utils.GenerateJWT(user.ID.Hex(), user.UnitID.Hex())
 	return c.JSON(models.APIResponse{
 		Status:  "success",
 		Message: "Login successful",

--- a/controllers/menu_controller.go
+++ b/controllers/menu_controller.go
@@ -5,6 +5,8 @@ import (
 	"go-fiber-api/repositories"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v4"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type MenuController struct {
@@ -25,6 +27,11 @@ func (ctrl *MenuController) CreateMenu(c *fiber.Ctx) error {
 		})
 	}
 
+	token := c.Locals("user").(*jwt.Token)
+	claims := token.Claims.(jwt.MapClaims)
+	unitIDHex, _ := claims["unit_id"].(string)
+	menu.UnitID, _ = primitive.ObjectIDFromHex(unitIDHex)
+
 	if err := ctrl.Repo.Create(c.Context(), &menu); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
@@ -42,7 +49,12 @@ func (ctrl *MenuController) CreateMenu(c *fiber.Ctx) error {
 
 func (ctrl *MenuController) GetMenus(c *fiber.Ctx) error {
 	search := c.Query("search")
-	menus, err := ctrl.Repo.GetAll(c.Context(), search)
+	token := c.Locals("user").(*jwt.Token)
+	claims := token.Claims.(jwt.MapClaims)
+	unitIDHex, _ := claims["unit_id"].(string)
+	uid, _ := primitive.ObjectIDFromHex(unitIDHex)
+
+	menus, err := ctrl.Repo.GetAll(c.Context(), uid, search)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
@@ -73,7 +85,12 @@ func (ctrl *MenuController) DeleteMenu(c *fiber.Ctx) error {
 		})
 	}
 
-	if err := ctrl.Repo.DeleteByID(c.Context(), id); err != nil {
+	token := c.Locals("user").(*jwt.Token)
+	claims := token.Claims.(jwt.MapClaims)
+	unitIDHex, _ := claims["unit_id"].(string)
+	uid, _ := primitive.ObjectIDFromHex(unitIDHex)
+
+	if err := ctrl.Repo.DeleteByID(c.Context(), uid, id); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
 			Message: err.Error(),
@@ -106,7 +123,12 @@ func (ctrl *MenuController) UpdateMenu(c *fiber.Ctx) error {
 		})
 	}
 
-	if err := ctrl.Repo.UpdateByID(c.Context(), menu.ID.Hex(), &menu); err != nil {
+	token := c.Locals("user").(*jwt.Token)
+	claims := token.Claims.(jwt.MapClaims)
+	unitIDHex, _ := claims["unit_id"].(string)
+	uid, _ := primitive.ObjectIDFromHex(unitIDHex)
+
+	if err := ctrl.Repo.UpdateByID(c.Context(), uid, menu.ID.Hex(), &menu); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
 			Message: err.Error(),

--- a/controllers/unit_controller.go
+++ b/controllers/unit_controller.go
@@ -1,0 +1,120 @@
+package controllers
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type UnitController struct {
+	Repo *repositories.UnitRepository
+}
+
+func NewUnitController(repo *repositories.UnitRepository) *UnitController {
+	return &UnitController{Repo: repo}
+}
+
+func (ctrl *UnitController) CreateUnit(c *fiber.Ctx) error {
+	var unit models.Unit
+	if err := c.BodyParser(&unit); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid data",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Create(c.Context(), &unit); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Unable to create unit",
+			Data:    nil,
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Created unit successfully",
+		Data:    unit.ToResponse(),
+	})
+}
+
+func (ctrl *UnitController) GetUnits(c *fiber.Ctx) error {
+	search := c.Query("search")
+	page, _ := strconv.ParseInt(c.Query("page", "1"), 10, 64)
+	limit, _ := strconv.ParseInt(c.Query("limit", "10"), 10, 64)
+	units, total, err := ctrl.Repo.GetAll(c.Context(), search, page, limit)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Cannot get unit list",
+			Data:    nil,
+		})
+	}
+	resp := make([]models.UnitResponse, len(units))
+	for i, u := range units {
+		resp[i] = u.ToResponse()
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Get unit list successfully",
+		Data: fiber.Map{
+			"items": resp,
+			"total": total,
+		},
+	})
+}
+
+func (ctrl *UnitController) UpdateUnit(c *fiber.Ctx) error {
+	var unit models.Unit
+	if err := c.BodyParser(&unit); err != nil || unit.ID.IsZero() {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid data",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.UpdateByID(c.Context(), unit.ID.Hex(), &unit); err != nil {
+		status := fiber.StatusInternalServerError
+		if err.Error() == "unit not found" {
+			status = fiber.StatusNotFound
+		}
+		return c.Status(status).JSON(models.APIResponse{
+			Status:  "error",
+			Message: err.Error(),
+			Data:    nil,
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Updated unit successfully",
+		Data:    unit.ToResponse(),
+	})
+}
+
+func (ctrl *UnitController) DeleteUnit(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.DeleteByID(c.Context(), id); err != nil {
+		status := fiber.StatusInternalServerError
+		if err.Error() == "unit not found" {
+			status = fiber.StatusNotFound
+		}
+		return c.Status(status).JSON(models.APIResponse{
+			Status:  "error",
+			Message: err.Error(),
+			Data:    nil,
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Deleted unit successfully",
+		Data:    nil,
+	})
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/joho/godotenv"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 	unitID := seed.SeedDefaultUnit()
 	seed.SeedRoleGroups(unitID)
 	seed.SeedAdminUser(unitID)
-	seed.SeedSAUser(unitID)
+	seed.SeedSAUser(primitive.NilObjectID)
 	seed.SeedDefaultUser(unitID)
 	seed.SeedMenus(unitID)
 

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ func main() {
 	config.ConnectDB()
 
 	// Seed default data
-	seed.SeedRoleGroups()
 	unitID := seed.SeedDefaultUnit()
+	seed.SeedRoleGroups(unitID)
 	seed.SeedAdminUser(unitID)
 	seed.SeedSAUser(unitID)
 	seed.SeedDefaultUser(unitID)

--- a/main.go
+++ b/main.go
@@ -24,11 +24,13 @@ func main() {
 	// Kết nối MongoDB một lần duy nhất
 	config.ConnectDB()
 
-	// Seed default accounts if needed
+	// Seed default data
 	seed.SeedRoleGroups()
-	seed.SeedAdminUser()
-	seed.SeedDefaultUser()
-	seed.SeedMenus()
+	unitID := seed.SeedDefaultUnit()
+	seed.SeedAdminUser(unitID)
+	seed.SeedSAUser(unitID)
+	seed.SeedDefaultUser(unitID)
+	seed.SeedMenus(unitID)
 
 	app := fiber.New()
 	app.Use(cors.New())

--- a/models/menu.go
+++ b/models/menu.go
@@ -4,39 +4,42 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Menu represents a navigation entry.
 type Menu struct {
-    ID            primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-    Title         string             `json:"title" bson:"title"`
-    Key           string             `json:"key" bson:"key"`
-    URL           string             `json:"url" bson:"url"`
-    Icon          string             `json:"icon" bson:"icon"`
-    ParentID      primitive.ObjectID `json:"parent_Id" bson:"parent_Id"`
-    PermissionBit int64              `json:"permissionBit" bson:"permissionBit"`
+	ID            primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Title         string             `json:"title" bson:"title"`
+	Key           string             `json:"key" bson:"key"`
+	URL           string             `json:"url" bson:"url"`
+	Icon          string             `json:"icon" bson:"icon"`
+	ParentID      primitive.ObjectID `json:"parent_Id" bson:"parent_Id"`
+	PermissionBit int64              `json:"permissionBit" bson:"permissionBit"`
+	UnitID        primitive.ObjectID `json:"unit_id" bson:"unit_id"`
 }
 
 // MenuResponse is used when returning menus to clients.
 type MenuResponse struct {
-    ID            primitive.ObjectID  `json:"id"`
-    Title         string              `json:"title"`
-    Key           string              `json:"key"`
-    URL           string              `json:"url"`
-    Icon          string              `json:"icon"`
-    ParentID      *primitive.ObjectID `json:"parent_Id"`
-    PermissionBit int64               `json:"permissionBit"`
+	ID            primitive.ObjectID  `json:"id"`
+	Title         string              `json:"title"`
+	Key           string              `json:"key"`
+	URL           string              `json:"url"`
+	Icon          string              `json:"icon"`
+	ParentID      *primitive.ObjectID `json:"parent_Id"`
+	PermissionBit int64               `json:"permissionBit"`
+	UnitID        string              `json:"unit_id"`
 }
 
 // ToResponse converts a Menu to a MenuResponse, setting ParentID to nil when it is zero.
 func (m Menu) ToResponse() MenuResponse {
-    var pid *primitive.ObjectID
-    if !m.ParentID.IsZero() {
-        pid = &m.ParentID
-    }
-    return MenuResponse{
-        ID:            m.ID,
-        Title:         m.Title,
-        Key:           m.Key,
-        URL:           m.URL,
-        Icon:          m.Icon,
-        ParentID:      pid,
-        PermissionBit: m.PermissionBit,
-    }
+	var pid *primitive.ObjectID
+	if !m.ParentID.IsZero() {
+		pid = &m.ParentID
+	}
+	return MenuResponse{
+		ID:            m.ID,
+		Title:         m.Title,
+		Key:           m.Key,
+		URL:           m.URL,
+		Icon:          m.Icon,
+		ParentID:      pid,
+		PermissionBit: m.PermissionBit,
+		UnitID:        m.UnitID.Hex(),
+	}
 }

--- a/models/role_group.go
+++ b/models/role_group.go
@@ -14,6 +14,7 @@ type RoleGroup struct {
 	Name        string             `json:"name" bson:"name"`
 	Description string             `json:"description" bson:"description"`
 	Permission  []PermissionDetail `json:"permission" bson:"permission"`
+	UnitID      primitive.ObjectID `json:"unit_id" bson:"unit_id"`
 }
 
 // RoleGroupResponse is used when returning role groups to clients.
@@ -22,6 +23,7 @@ type RoleGroupResponse struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description"`
 	Permission  []PermissionDetail `json:"permission"`
+	UnitID      string             `json:"unit_id"`
 }
 
 // RoleGroupListItem is a lightweight representation used when listing groups.
@@ -29,6 +31,7 @@ type RoleGroupListItem struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	UnitID      string `json:"unit_id"`
 }
 
 // ToResponse converts a RoleGroup to RoleGroupResponse.
@@ -38,6 +41,7 @@ func (r RoleGroup) ToResponse() RoleGroupResponse {
 		Name:        r.Name,
 		Description: r.Description,
 		Permission:  r.Permission,
+		UnitID:      r.UnitID.Hex(),
 	}
 }
 
@@ -47,5 +51,6 @@ func (r RoleGroup) ToListItem() RoleGroupListItem {
 		ID:          r.ID.Hex(),
 		Name:        r.Name,
 		Description: r.Description,
+		UnitID:      r.UnitID.Hex(),
 	}
 }

--- a/models/unit.go
+++ b/models/unit.go
@@ -1,0 +1,26 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// Unit represents a site or department in a multi-site setup.
+type Unit struct {
+	ID   primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name string             `json:"name" bson:"name"`
+	Code string             `json:"code" bson:"code"`
+}
+
+// UnitResponse is used when returning units to clients.
+type UnitResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Code string `json:"code"`
+}
+
+// ToResponse converts a Unit to UnitResponse.
+func (u Unit) ToResponse() UnitResponse {
+	return UnitResponse{
+		ID:   u.ID.Hex(),
+		Name: u.Name,
+		Code: u.Code,
+	}
+}

--- a/models/user.go
+++ b/models/user.go
@@ -10,6 +10,7 @@ type User struct {
 	Name       string               `json:"name" bson:"name"`
 	UrlAvatar  string               `json:"url_avatar" bson:"url_avatar"`
 	RoleGroups []primitive.ObjectID `json:"role_groups" bson:"role_groups"`
+	UnitID     primitive.ObjectID   `json:"unit_id" bson:"unit_id"`
 }
 
 // UserListItem represents a user with role group details populated.
@@ -19,6 +20,7 @@ type UserListItem struct {
 	Name       string              `json:"name"`
 	UrlAvatar  string              `json:"url_avatar"`
 	RoleGroups []RoleGroupListItem `json:"role_groups"`
+	UnitID     string              `json:"unit_id"`
 }
 
 // ToListItem converts a User to UserListItem with role group details.
@@ -35,5 +37,6 @@ func (u User) ToListItem(groups map[primitive.ObjectID]RoleGroupListItem) UserLi
 		Name:       u.Name,
 		UrlAvatar:  u.UrlAvatar,
 		RoleGroups: rg,
+		UnitID:     u.UnitID.Hex(),
 	}
 }

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -475,6 +475,87 @@
       ]
     },
     {
+      "name": "Unit",
+      "item": [
+        {
+          "name": "Get Units",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units?page=1&limit=10&search=unit",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ],
+              "query": [
+                {"key": "page", "value": "1"},
+                {"key": "limit", "value": "10"},
+                {"key": "search", "value": "unit"}
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Unit",
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Site A\",\n  \"code\": \"A\"\n}"
+            },
+            "url": {"raw": "{{baseUrl}}/api/units", "host": ["{{baseUrl}}"], "path": ["api", "units"]}
+          },
+          "response": []
+        },
+        {
+          "name": "Update Unit",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"000000000000000000000000\",\n  \"name\": \"Site A Updated\",\n  \"code\": \"A1\"\n}"
+            },
+            "url": {"raw": "{{baseUrl}}/api/units", "host": ["{{baseUrl}}"], "path": ["api", "units"]}
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Unit",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{token}}"}
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units?id=000000000000000000000000",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "units"],
+              "query": [{"key": "id", "value": "000000000000000000000000"}]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
       "name": "Role Group",
       "item": [
         {

--- a/repositories/menu_repository.go
+++ b/repositories/menu_repository.go
@@ -25,8 +25,8 @@ func (r *MenuRepository) Create(ctx context.Context, menu *models.Menu) error {
 }
 
 // GetAll returns menus optionally filtered by a search keyword.
-func (r *MenuRepository) GetAll(ctx context.Context, search string) ([]models.Menu, error) {
-	filter := bson.M{}
+func (r *MenuRepository) GetAll(ctx context.Context, unitID primitive.ObjectID, search string) ([]models.Menu, error) {
+	filter := bson.M{"unit_id": unitID}
 	if search != "" {
 		filter["title"] = bson.M{"$regex": search, "$options": "i"}
 	}
@@ -48,12 +48,12 @@ func (r *MenuRepository) GetAll(ctx context.Context, search string) ([]models.Me
 	return menus, nil
 }
 
-func (r *MenuRepository) DeleteByID(ctx context.Context, id string) error {
+func (r *MenuRepository) DeleteByID(ctx context.Context, unitID primitive.ObjectID, id string) error {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return err
 	}
-	res, err := r.collection.DeleteOne(ctx, bson.M{"_id": objID})
+	res, err := r.collection.DeleteOne(ctx, bson.M{"_id": objID, "unit_id": unitID})
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (r *MenuRepository) DeleteByID(ctx context.Context, id string) error {
 	return nil
 }
 
-func (r *MenuRepository) UpdateByID(ctx context.Context, id string, menu *models.Menu) error {
+func (r *MenuRepository) UpdateByID(ctx context.Context, unitID primitive.ObjectID, id string, menu *models.Menu) error {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (r *MenuRepository) UpdateByID(ctx context.Context, id string, menu *models
 		"permissionBit": menu.PermissionBit,
 	}}
 
-	res, err := r.collection.UpdateOne(ctx, bson.M{"_id": objID}, update)
+	res, err := r.collection.UpdateOne(ctx, bson.M{"_id": objID, "unit_id": unitID}, update)
 	if err != nil {
 		return err
 	}

--- a/repositories/unit_repository.go
+++ b/repositories/unit_repository.go
@@ -1,0 +1,90 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"go-fiber-api/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type UnitRepository struct {
+	collection *mongo.Collection
+}
+
+func NewUnitRepository(db *mongo.Database) *UnitRepository {
+	return &UnitRepository{collection: db.Collection("units")}
+}
+
+func (r *UnitRepository) Create(ctx context.Context, unit *models.Unit) error {
+	unit.ID = primitive.NewObjectID()
+	_, err := r.collection.InsertOne(ctx, unit)
+	return err
+}
+
+func (r *UnitRepository) GetAll(ctx context.Context, search string, page, limit int64) ([]models.Unit, int64, error) {
+	filter := bson.M{}
+	if search != "" {
+		filter["name"] = bson.M{"$regex": search, "$options": "i"}
+	}
+	opts := options.Find()
+	if limit > 0 {
+		opts.SetLimit(limit).SetSkip((page - 1) * limit)
+	}
+	cursor, err := r.collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+	var units []models.Unit
+	for cursor.Next(ctx) {
+		var u models.Unit
+		if err := cursor.Decode(&u); err != nil {
+			return nil, 0, err
+		}
+		units = append(units, u)
+	}
+	total, err := r.collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+	return units, total, nil
+}
+
+func (r *UnitRepository) UpdateByID(ctx context.Context, id string, unit *models.Unit) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	update := bson.M{"$set": bson.M{
+		"name": unit.Name,
+		"code": unit.Code,
+	}}
+	res, err := r.collection.UpdateOne(ctx, bson.M{"_id": objID}, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return errors.New("unit not found")
+	}
+	unit.ID = objID
+	return nil
+}
+
+func (r *UnitRepository) DeleteByID(ctx context.Context, id string) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	res, err := r.collection.DeleteOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return errors.New("unit not found")
+	}
+	return nil
+}

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -49,8 +49,8 @@ func (r *UserRepository) IsUsernameExists(ctx context.Context, username string) 
 
 // GetAll returns a paginated list of users filtered by username keyword.
 // It also returns the total number of matched documents for pagination.
-func (r *UserRepository) GetAll(ctx context.Context, search string, page, limit int64) ([]models.User, int64, error) {
-	filter := bson.M{}
+func (r *UserRepository) GetAll(ctx context.Context, unitID primitive.ObjectID, search string, page, limit int64) ([]models.User, int64, error) {
+	filter := bson.M{"unit_id": unitID}
 	if search != "" {
 		filter["username"] = bson.M{"$regex": search, "$options": "i"}
 	}
@@ -119,7 +119,7 @@ func (r *UserRepository) FindByID(ctx context.Context, id string) (*models.User,
 
 // UpdateByID updates the name, avatar URL, and role groups of a user by id and
 // returns the updated document. Username and password cannot be changed here.
-func (r *UserRepository) UpdateByID(ctx context.Context, id string, name string, urlAvatar string, roleGroups []primitive.ObjectID) (*models.User, error) {
+func (r *UserRepository) UpdateByID(ctx context.Context, unitID primitive.ObjectID, id string, name string, urlAvatar string, roleGroups []primitive.ObjectID) (*models.User, error) {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (r *UserRepository) UpdateByID(ctx context.Context, id string, name string,
 
 	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
 	var updated models.User
-	err = r.collection.FindOneAndUpdate(ctx, bson.M{"_id": objID}, update, opts).Decode(&updated)
+	err = r.collection.FindOneAndUpdate(ctx, bson.M{"_id": objID, "unit_id": unitID}, update, opts).Decode(&updated)
 	if err == mongo.ErrNoDocuments {
 		return nil, errors.New("user not found")
 	}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,6 +17,8 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	authCtrl := controllers.NewAuthController(userRepo, roleGroupRepo)
 	menuRepo := repositories.NewMenuRepository(db)
 	menuCtrl := controllers.NewMenuController(menuRepo)
+	unitRepo := repositories.NewUnitRepository(db)
+	unitCtrl := controllers.NewUnitController(unitRepo)
 	roleGroupCtrl := controllers.NewRoleGroupController(roleGroupRepo)
 
 	// Public routes do not require authentication
@@ -46,6 +48,12 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	menuAdmin.Put("/", menuCtrl.UpdateMenu)
 	menuAdmin.Get("/", menuCtrl.GetMenus)
 	menuAdmin.Delete("/", menuCtrl.DeleteMenu)
+
+	unitAdmin := api.Group("/units")
+	unitAdmin.Post("/", unitCtrl.CreateUnit)
+	unitAdmin.Put("/", unitCtrl.UpdateUnit)
+	unitAdmin.Get("/", unitCtrl.GetUnits)
+	unitAdmin.Delete("/", unitCtrl.DeleteUnit)
 
 	roleGroupAdmin := api.Group("/role-groups")
 	roleGroupAdmin.Post("/", roleGroupCtrl.CreateRoleGroup)

--- a/seed/constants.go
+++ b/seed/constants.go
@@ -1,6 +1,0 @@
-package seed
-
-import "go.mongodb.org/mongo-driver/bson/primitive"
-
-// DefaultUnitID is the fixed ID used when seeding the default unit and related data.
-var DefaultUnitID, _ = primitive.ObjectIDFromHex("687f156bb677e045a4ade130")

--- a/seed/constants.go
+++ b/seed/constants.go
@@ -1,0 +1,6 @@
+package seed
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// DefaultUnitID is the fixed ID used when seeding the default unit and related data.
+var DefaultUnitID, _ = primitive.ObjectIDFromHex("687f156bb677e045a4ade130")

--- a/seed/menu.go
+++ b/seed/menu.go
@@ -13,7 +13,7 @@ import (
 )
 
 // SeedMenus inserts default menu entries if they do not exist.
-func SeedMenus() {
+func SeedMenus(unitID primitive.ObjectID) {
 	collection := config.DB.Collection("menus")
 
 	menus := []models.Menu{}
@@ -27,6 +27,7 @@ func SeedMenus() {
 		Icon:          "ant-design:dashboard-outlined",
 		ParentID:      primitive.NilObjectID,
 		PermissionBit: 0,
+		UnitID:        unitID,
 	})
 
 	id2, _ := primitive.ObjectIDFromHex("685d058f394165c3d5a0c626")
@@ -38,6 +39,7 @@ func SeedMenus() {
 		Icon:          "ant-design:user-outlined",
 		ParentID:      primitive.NilObjectID,
 		PermissionBit: 2,
+		UnitID:        unitID,
 	})
 
 	id3, _ := primitive.ObjectIDFromHex("685d05d3394165c3d5a0c627")
@@ -49,6 +51,7 @@ func SeedMenus() {
 		Icon:          "ant-design:menu-outlined",
 		ParentID:      id2,
 		PermissionBit: 0,
+		UnitID:        unitID,
 	})
 
 	id4, _ := primitive.ObjectIDFromHex("685d0d98ba911d2a1d9f40ea")
@@ -60,6 +63,7 @@ func SeedMenus() {
 		Icon:          "ant-design:safety-outlined",
 		ParentID:      id2,
 		PermissionBit: 2,
+		UnitID:        unitID,
 	})
 
 	id5, _ := primitive.ObjectIDFromHex("685e0007bd9eb34fceea7f4c")
@@ -71,6 +75,7 @@ func SeedMenus() {
 		Icon:          "ant-design:user-outlined",
 		ParentID:      id2,
 		PermissionBit: 4,
+		UnitID:        unitID,
 	})
 
 	for _, m := range menus {

--- a/seed/role_group.go
+++ b/seed/role_group.go
@@ -13,7 +13,7 @@ import (
 )
 
 // SeedRoleGroups seeds default role groups if they don't already exist.
-func SeedRoleGroups() {
+func SeedRoleGroups(unitID primitive.ObjectID) {
 	collection := config.DB.Collection("role_groups")
 
 	adminID, _ := primitive.ObjectIDFromHex("685d01ab5e17ba55d0e349f2")
@@ -26,6 +26,7 @@ func SeedRoleGroups() {
 			{Key: "menu-euoi92n7f0", PermissionValue: 0},
 			{Key: "menu-byy4w5x6la", PermissionValue: 42},
 		},
+		UnitID: unitID,
 	}
 
 	var existing models.RoleGroup

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -1,0 +1,39 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+
+	"go-fiber-api/config"
+	"go-fiber-api/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func SeedDefaultUnit() primitive.ObjectID {
+	collection := config.DB.Collection("units")
+	var existing models.Unit
+	err := collection.FindOne(context.TODO(), bson.M{"code": "default"}).Decode(&existing)
+	if err == mongo.ErrNoDocuments {
+		id := primitive.NewObjectID()
+		unit := models.Unit{
+			ID:   id,
+			Name: "Default Unit",
+			Code: "default",
+		}
+		if _, err := collection.InsertOne(context.TODO(), unit); err != nil {
+			fmt.Println("❌ Failed to seed default unit:", err)
+			return primitive.NilObjectID
+		}
+		fmt.Println("🚀 Default unit seeded")
+		return id
+	} else if err == nil {
+		fmt.Println("✅ Default unit already exists")
+		return existing.ID
+	} else {
+		fmt.Println("❌ Failed checking default unit:", err)
+		return primitive.NilObjectID
+	}
+}

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -12,13 +12,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+var defaultUnitID, _ = primitive.ObjectIDFromHex("687f156bb677e045a4ade130")
+
 func SeedDefaultUnit() primitive.ObjectID {
 	collection := config.DB.Collection("units")
 	var existing models.Unit
-	err := collection.FindOne(context.TODO(), bson.M{"_id": DefaultUnitID}).Decode(&existing)
+	err := collection.FindOne(context.TODO(), bson.M{"_id": defaultUnitID}).Decode(&existing)
 	if err == mongo.ErrNoDocuments {
 		unit := models.Unit{
-			ID:   DefaultUnitID,
+			ID:   defaultUnitID,
 			Name: "Default Unit",
 			Code: "default",
 		}
@@ -27,7 +29,7 @@ func SeedDefaultUnit() primitive.ObjectID {
 			return primitive.NilObjectID
 		}
 		fmt.Println("🚀 Default unit seeded")
-		return DefaultUnitID
+		return defaultUnitID
 	} else if err == nil {
 		fmt.Println("✅ Default unit already exists")
 		return existing.ID

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -15,11 +15,10 @@ import (
 func SeedDefaultUnit() primitive.ObjectID {
 	collection := config.DB.Collection("units")
 	var existing models.Unit
-	err := collection.FindOne(context.TODO(), bson.M{"code": "default"}).Decode(&existing)
+	err := collection.FindOne(context.TODO(), bson.M{"_id": DefaultUnitID}).Decode(&existing)
 	if err == mongo.ErrNoDocuments {
-		id := primitive.NewObjectID()
 		unit := models.Unit{
-			ID:   id,
+			ID:   DefaultUnitID,
 			Name: "Default Unit",
 			Code: "default",
 		}
@@ -28,7 +27,7 @@ func SeedDefaultUnit() primitive.ObjectID {
 			return primitive.NilObjectID
 		}
 		fmt.Println("🚀 Default unit seeded")
-		return id
+		return DefaultUnitID
 	} else if err == nil {
 		fmt.Println("✅ Default unit already exists")
 		return existing.ID

--- a/seed/user.go
+++ b/seed/user.go
@@ -66,12 +66,8 @@ func SeedDefaultUser(unitID primitive.ObjectID) {
 	fmt.Println("🚀 Regular user seeded successfully: username=user password=user123")
 }
 
-// SeedSAUser creates a super admin tied to the provided unit.
+// SeedSAUser creates a super admin not tied to any unit.
 func SeedSAUser(unitID primitive.ObjectID) {
-	if unitID.IsZero() {
-		fmt.Println("❌ Cannot seed SA user without unit")
-		return
-	}
 	collection := config.DB.Collection("users")
 	var existing models.User
 	err := collection.FindOne(context.TODO(), bson.M{"username": "sa"}).Decode(&existing)
@@ -87,7 +83,7 @@ func SeedSAUser(unitID primitive.ObjectID) {
 		Name:       "Super Admin",
 		UrlAvatar:  "",
 		RoleGroups: []primitive.ObjectID{groupID},
-		UnitID:     unitID,
+		UnitID:     primitive.NilObjectID,
 	}
 	if _, err := collection.InsertOne(context.TODO(), sa); err != nil {
 		fmt.Println("❌ Failed to seed SA user:", err)

--- a/utils/hash.go
+++ b/utils/hash.go
@@ -18,10 +18,11 @@ func CheckPasswordHash(password, hash string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 	return err == nil
 }
-func GenerateJWT(id string) (string, error) {
+func GenerateJWT(id string, unitID string) (string, error) {
 	claims := jwt.MapClaims{
-		"id":  id,
-		"exp": time.Now().Add(12 * time.Hour).Unix(), // Hết hạn sau 12 giờ
+		"id":      id,
+		"unit_id": unitID,
+		"exp":     time.Now().Add(12 * time.Hour).Unix(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)


### PR DESCRIPTION
## Summary
- add UnitID field to users, menus and role groups
- remove domain from units
- include unit_id in JWT and restrict CRUD by unit
- seed a default unit plus SA account
- update Postman examples for units

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_687f0fd0bb38832682732b45eaa91c66