### PR TITLE
Use query param for unit operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ The response includes the user's `unit_id` and an `is_admin` flag. If you pass
 `"admin"` as the sub-domain, the credentials will be checked against service
 accounts instead of regular users. A default admin service account is seeded
 with name `sa` and password `sa123`.
+
+Both the unit and service-account list endpoints support optional search and
+pagination:
+
+```
+GET /api/units?page=1&limit=20&search=demo
+GET /api/service_accounts?page=1&limit=20&search=sa
+```
+
+If `page` or `limit` are omitted the full list is returned.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ When logging in, include the unit's sub-domain along with the username and passw
 }
 ```
 
-The response includes the user's `unit_id` and an `is_admin` flag.
+The response includes the user's `unit_id` and an `is_admin` flag. If you pass
+`"admin"` as the sub-domain, the credentials will be checked against service
+accounts instead of regular users.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ assumes two variables:
 The collection contains examples for logging in and obtaining presigned URLs
 for uploading images.
 
-When logging in, include the unit ID along with the username and password:
+When logging in, include the unit's sub-domain along with the username and password:
 
 ```json
 {
   "username": "admin",
   "password": "admin123",
-  "unit_id": "687f569bcd2015c348afcc27"
+  "sub_domain": "admin"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ When logging in, include the unit's sub-domain along with the username and passw
   "sub_domain": "admin"
 }
 ```
+
+The response includes the user's `unit_id` and an `is_admin` flag.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ When logging in, include the unit's sub-domain along with the username and passw
 
 The response includes the user's `unit_id` and an `is_admin` flag. If you pass
 `"admin"` as the sub-domain, the credentials will be checked against service
-accounts instead of regular users.
+accounts instead of regular users. A default admin service account is seeded
+with name `admin` and password `admin123`.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ assumes two variables:
 
 The collection contains examples for logging in and obtaining presigned URLs
 for uploading images.
+
+When logging in, include the unit ID along with the username and password:
+
+```json
+{
+  "username": "admin",
+  "password": "admin123",
+  "unit_id": "687f569bcd2015c348afcc27"
+}
+```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ assumes two variables:
 The collection contains examples for logging in and obtaining presigned URLs
 for uploading images.
 
-To verify if a sub-domain is available, send a GET request to
+To fetch unit details by sub-domain, send a GET request to
 `/api/units/by_subdomain?sub_domain=yourname` without authentication. The
-response will indicate whether the sub-domain already exists.
+response includes the unit's name, logo and sub-domain. If the sub-domain does
+not exist, the API returns an error message "sub domain not found".
 
 When logging in, include the unit's sub-domain along with the username and password:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ assumes two variables:
 The collection contains examples for logging in and obtaining presigned URLs
 for uploading images.
 
+To verify if a sub-domain is available, send a GET request to
+`/api/units/by_subdomain?sub_domain=yourname` without authentication. The
+response will indicate whether the sub-domain already exists.
+
 When logging in, include the unit's sub-domain along with the username and password:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ When logging in, include the unit's sub-domain along with the username and passw
 The response includes the user's `unit_id` and an `is_admin` flag. If you pass
 `"admin"` as the sub-domain, the credentials will be checked against service
 accounts instead of regular users. A default admin service account is seeded
-with name `admin` and password `admin123`.
+with name `sa` and password `sa123`.

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -34,14 +34,14 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		})
 	}
 
-       user, err := ctrl.Repo.FindByUsername(c.Context(), input.Username)
-       if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
-               return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
-                       Status:  "error",
-                       Message: "Invalid credentials",
-                       Data:    nil,
-               })
-       }
+	user, err := ctrl.Repo.FindByUsername(c.Context(), input.Username)
+	if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
+		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid credentials",
+			Data:    nil,
+		})
+	}
 
 	token, _ := utils.GenerateJWT(user.ID.Hex())
 	u := fiber.Map{
@@ -49,6 +49,7 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		"username":   user.Username,
 		"name":       user.Name,
 		"url_avatar": user.UrlAvatar,
+		"unit_id":    user.UnitID.Hex(),
 	}
 
 	return c.JSON(models.APIResponse{

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -34,14 +34,14 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		})
 	}
 
-	user, err := ctrl.Repo.FindByUsername(c.Context(), input.Username)
-	if err != nil || !utils.CheckPasswordHash(input.Password, user.Password) {
-		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
-			Status:  "error",
-			Message: "Invalid credentials",
-			Data:    nil,
-		})
-	}
+       user, err := ctrl.Repo.FindByUsername(c.Context(), input.Username)
+       if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
+               return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Invalid credentials",
+                       Data:    nil,
+               })
+       }
 
 	token, _ := utils.GenerateJWT(user.ID.Hex())
 	u := fiber.Map{

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -12,12 +12,13 @@ import (
 
 // AuthController handles authentication requests.
 type AuthController struct {
-	Repo *repositories.UserRepository
+	UserRepo *repositories.UserRepository
+	UnitRepo *repositories.UnitRepository
 }
 
 // NewAuthController creates a controller with the provided user repository.
-func NewAuthController(repo *repositories.UserRepository) *AuthController {
-	return &AuthController{Repo: repo}
+func NewAuthController(userRepo *repositories.UserRepository, unitRepo *repositories.UnitRepository) *AuthController {
+	return &AuthController{UserRepo: userRepo, UnitRepo: unitRepo}
 }
 
 // Login authenticates a user and returns a signed JWT on success.
@@ -25,6 +26,7 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 	var input struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
+		UnitID   string `json:"unit_id"`
 	}
 	if err := c.BodyParser(&input); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
@@ -34,8 +36,25 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		})
 	}
 
-	user, err := ctrl.Repo.FindByUsername(c.Context(), input.Username)
-	if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
+	if input.UnitID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing unit_id",
+			Data:    nil,
+		})
+	}
+
+	user, err := ctrl.UserRepo.FindByUsername(c.Context(), input.Username)
+	if err != nil || user.UnitID.Hex() != input.UnitID || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
+		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid credentials",
+			Data:    nil,
+		})
+	}
+
+	unit, err := ctrl.UnitRepo.FindByID(c.Context(), input.UnitID)
+	if err != nil || !unit.Active {
 		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
 			Status:  "error",
 			Message: "Invalid credentials",

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -46,7 +46,7 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 	}
 
 	if input.SubDomain == "admin" {
-		sa, err := ctrl.SARepo.FindByName(c.Context(), input.Username)
+		sa, err := ctrl.SARepo.FindByUsername(c.Context(), input.Username)
 		if err != nil || !sa.Active || !utils.CheckPasswordHash(input.Password, sa.Password) {
 			return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
 				Status:  "error",
@@ -56,8 +56,9 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		}
 		token, _ := utils.GenerateJWT(sa.ID.Hex())
 		s := fiber.Map{
-			"id":   sa.ID.Hex(),
-			"name": sa.Name,
+			"id":       sa.ID.Hex(),
+			"username": sa.Username,
+			"name":     sa.Name,
 		}
 		return c.JSON(models.APIResponse{
 			Status:  "success",

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -23,11 +23,11 @@ func NewAuthController(userRepo *repositories.UserRepository, unitRepo *reposito
 
 // Login authenticates a user and returns a signed JWT on success.
 func (ctrl *AuthController) Login(c *fiber.Ctx) error {
-       var input struct {
-               Username  string `json:"username"`
-               Password  string `json:"password"`
-               SubDomain string `json:"sub_domain"`
-       }
+	var input struct {
+		Username  string `json:"username"`
+		Password  string `json:"password"`
+		SubDomain string `json:"sub_domain"`
+	}
 	if err := c.BodyParser(&input); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
 			Status:  "error",
@@ -36,29 +36,29 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		})
 	}
 
-       if input.SubDomain == "" {
-               return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
-                       Status:  "error",
-                       Message: "Missing sub_domain",
-                       Data:    nil,
-               })
-       }
+	if input.SubDomain == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing sub_domain",
+			Data:    nil,
+		})
+	}
 
-       user, err := ctrl.UserRepo.FindByUsername(c.Context(), input.Username)
-       if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
-               return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
-                       Status:  "error",
-                       Message: "Invalid credentials",
-                       Data:    nil,
-               })
-       }
-       unit, err := ctrl.UnitRepo.FindBySubDomain(c.Context(), input.SubDomain)
-       if err != nil || !unit.Active || user.UnitID != unit.ID {
-               return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
-                       Status:  "error",
-                       Message: "Invalid credentials",
-                       Data:    nil,
-               })
+	user, err := ctrl.UserRepo.FindByUsername(c.Context(), input.Username)
+	if err != nil || !user.Active || !utils.CheckPasswordHash(input.Password, user.Password) {
+		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid credentials",
+			Data:    nil,
+		})
+	}
+	unit, err := ctrl.UnitRepo.FindBySubDomain(c.Context(), input.SubDomain)
+	if err != nil || !unit.Active || user.UnitID != unit.ID {
+		return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid credentials",
+			Data:    nil,
+		})
 	}
 
 	token, _ := utils.GenerateJWT(user.ID.Hex())
@@ -68,6 +68,7 @@ func (ctrl *AuthController) Login(c *fiber.Ctx) error {
 		"name":       user.Name,
 		"url_avatar": user.UrlAvatar,
 		"unit_id":    user.UnitID.Hex(),
+		"is_admin":   user.IsAdmin,
 	}
 
 	return c.JSON(models.APIResponse{

--- a/controllers/service_account.go
+++ b/controllers/service_account.go
@@ -76,9 +76,10 @@ func (ctrl *ServiceAccountController) List(c *fiber.Ctx) error {
 			Data:    item,
 		})
 	}
-	page := c.QueryInt("page", 1)
-	limit := c.QueryInt("limit", 10)
-	items, total, err := ctrl.Repo.GetAll(c.Context(), int64(page), int64(limit))
+	search := c.Query("search")
+	page := c.QueryInt("page", 0)
+	limit := c.QueryInt("limit", 0)
+	items, total, err := ctrl.Repo.GetAll(c.Context(), search, int64(page), int64(limit))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",

--- a/controllers/service_account.go
+++ b/controllers/service_account.go
@@ -1,0 +1,132 @@
+package controllers
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type ServiceAccountController struct {
+	Repo *repositories.ServiceAccountRepository
+}
+
+func NewServiceAccountController(repo *repositories.ServiceAccountRepository) *ServiceAccountController {
+	return &ServiceAccountController{Repo: repo}
+}
+
+func (ctrl *ServiceAccountController) Create(c *fiber.Ctx) error {
+	var input models.ServiceAccount
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if input.Active == false {
+		input.Active = true
+	}
+	if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to create service account",
+			Data:    err.Error(),
+		})
+	}
+	return c.Status(fiber.StatusCreated).JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Service account created",
+		Data:    input,
+	})
+}
+
+func (ctrl *ServiceAccountController) List(c *fiber.Ctx) error {
+	if id := c.Query("id"); id != "" {
+		item, err := ctrl.Repo.FindByID(c.Context(), id)
+		if err != nil {
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Service account not found",
+				Data:    nil,
+			})
+		}
+		return c.JSON(models.APIResponse{
+			Status:  "success",
+			Message: "Service account retrieved",
+			Data:    item,
+		})
+	}
+	page := c.QueryInt("page", 1)
+	limit := c.QueryInt("limit", 10)
+	items, total, err := ctrl.Repo.GetAll(c.Context(), int64(page), int64(limit))
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to list service accounts",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Service accounts retrieved",
+		Data: fiber.Map{
+			"items": items,
+			"total": total,
+		},
+	})
+}
+
+func (ctrl *ServiceAccountController) Update(c *fiber.Ctx) error {
+	var input models.ServiceAccount
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if input.ID.IsZero() {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	id := input.ID.Hex()
+	if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to update service account",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Service account updated",
+		Data:    input,
+	})
+}
+
+func (ctrl *ServiceAccountController) Delete(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Delete(c.Context(), id); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to delete service account",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Service account deleted",
+		Data:    nil,
+	})
+}

--- a/controllers/service_account.go
+++ b/controllers/service_account.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"go-fiber-api/models"
 	"go-fiber-api/repositories"
+	"go-fiber-api/utils"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -27,6 +28,10 @@ func (ctrl *ServiceAccountController) Create(c *fiber.Ctx) error {
 	if input.Active == false {
 		input.Active = true
 	}
+	if input.Password != "" {
+		hashed, _ := utils.HashPassword(input.Password)
+		input.Password = hashed
+	}
 	if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
@@ -34,6 +39,7 @@ func (ctrl *ServiceAccountController) Create(c *fiber.Ctx) error {
 			Data:    err.Error(),
 		})
 	}
+	input.Password = ""
 	return c.Status(fiber.StatusCreated).JSON(models.APIResponse{
 		Status:  "success",
 		Message: "Service account created",
@@ -94,6 +100,10 @@ func (ctrl *ServiceAccountController) Update(c *fiber.Ctx) error {
 		})
 	}
 	id := input.ID.Hex()
+	if input.Password != "" {
+		hashed, _ := utils.HashPassword(input.Password)
+		input.Password = hashed
+	}
 	if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
@@ -101,6 +111,7 @@ func (ctrl *ServiceAccountController) Update(c *fiber.Ctx) error {
 			Data:    err.Error(),
 		})
 	}
+	input.Password = ""
 	return c.JSON(models.APIResponse{
 		Status:  "success",
 		Message: "Service account updated",

--- a/controllers/service_account.go
+++ b/controllers/service_account.go
@@ -25,7 +25,20 @@ func (ctrl *ServiceAccountController) Create(c *fiber.Ctx) error {
 			Data:    nil,
 		})
 	}
-	if input.Active == false {
+	if exists, err := ctrl.Repo.IsUsernameExists(c.Context(), input.Username); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to create service account",
+			Data:    err.Error(),
+		})
+	} else if exists {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "username exists",
+			Data:    nil,
+		})
+	}
+	if !input.Active {
 		input.Active = true
 	}
 	if input.Password != "" {

--- a/controllers/unit.go
+++ b/controllers/unit.go
@@ -1,0 +1,154 @@
+package controllers
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type UnitController struct {
+	Repo *repositories.UnitRepository
+}
+
+func NewUnitController(repo *repositories.UnitRepository) *UnitController {
+	return &UnitController{Repo: repo}
+}
+
+func (ctrl *UnitController) Create(c *fiber.Ctx) error {
+	var input models.Unit
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to create unit",
+			Data:    err.Error(),
+		})
+	}
+	return c.Status(fiber.StatusCreated).JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Unit created",
+		Data:    input,
+	})
+}
+
+func (ctrl *UnitController) List(c *fiber.Ctx) error {
+	if id := c.Query("id"); id != "" {
+		unit, err := ctrl.Repo.FindByID(c.Context(), id)
+		if err != nil {
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Unit not found",
+				Data:    nil,
+			})
+		}
+		return c.JSON(models.APIResponse{
+			Status:  "success",
+			Message: "Unit retrieved",
+			Data:    unit,
+		})
+	}
+
+	page := c.QueryInt("page", 1)
+	limit := c.QueryInt("limit", 10)
+	units, total, err := ctrl.Repo.GetAll(c.Context(), int64(page), int64(limit))
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to list units",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Units retrieved",
+		Data: fiber.Map{
+			"items": units,
+			"total": total,
+		},
+	})
+}
+
+func (ctrl *UnitController) Get(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	unit, err := ctrl.Repo.FindByID(c.Context(), id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Unit not found",
+			Data:    nil,
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Unit retrieved",
+		Data:    unit,
+	})
+}
+
+func (ctrl *UnitController) Update(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	var input models.Unit
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to update unit",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Unit updated",
+		Data:    input,
+	})
+}
+
+func (ctrl *UnitController) Delete(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Delete(c.Context(), id); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to delete unit",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Unit deleted",
+		Data:    nil,
+	})
+}

--- a/controllers/unit.go
+++ b/controllers/unit.go
@@ -72,9 +72,10 @@ func (ctrl *UnitController) List(c *fiber.Ctx) error {
 		})
 	}
 
-	page := c.QueryInt("page", 1)
-	limit := c.QueryInt("limit", 10)
-	units, total, err := ctrl.Repo.GetAll(c.Context(), int64(page), int64(limit))
+	search := c.Query("search")
+	page := c.QueryInt("page", 0)
+	limit := c.QueryInt("limit", 0)
+	units, total, err := ctrl.Repo.GetAll(c.Context(), search, int64(page), int64(limit))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",

--- a/controllers/unit.go
+++ b/controllers/unit.go
@@ -126,26 +126,30 @@ func (ctrl *UnitController) GetBySubDomain(c *fiber.Ctx) error {
 		})
 	}
 
-	_, err := ctrl.Repo.FindBySubDomain(c.Context(), sub)
+	unit, err := ctrl.Repo.FindBySubDomain(c.Context(), sub)
 	if err == mongo.ErrNoDocuments {
-		return c.JSON(models.APIResponse{
-			Status:  "success",
-			Message: "sub_domain available",
-			Data:    fiber.Map{"exists": false},
+		return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "sub domain not found",
+			Data:    nil,
 		})
 	}
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
-			Message: "Failed to check sub_domain",
+			Message: "Failed to fetch unit",
 			Data:    err.Error(),
 		})
 	}
 
 	return c.JSON(models.APIResponse{
 		Status:  "success",
-		Message: "sub_domain exists",
-		Data:    fiber.Map{"exists": true},
+		Message: "Unit retrieved",
+		Data: fiber.Map{
+			"name":       unit.Name,
+			"sub_domain": unit.SubDomain,
+			"logo":       unit.Logo,
+		},
 	})
 }
 

--- a/controllers/unit.go
+++ b/controllers/unit.go
@@ -17,8 +17,8 @@ func NewUnitController(repo *repositories.UnitRepository) *UnitController {
 }
 
 func (ctrl *UnitController) Create(c *fiber.Ctx) error {
-	var input models.Unit
-	if err := c.BodyParser(&input); err != nil {
+        var input models.Unit
+        if err := c.BodyParser(&input); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
 			Status:  "error",
 			Message: "Invalid input",
@@ -37,8 +37,11 @@ func (ctrl *UnitController) Create(c *fiber.Ctx) error {
 			Message: "Failed to create unit",
 			Data:    err.Error(),
 		})
-	}
-	if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
+        }
+       if input.Active == false {
+               input.Active = true
+       }
+        if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
 			Status:  "error",
 			Message: "Failed to create unit",
@@ -138,27 +141,28 @@ func (ctrl *UnitController) GetBySubDomain(c *fiber.Ctx) error {
 }
 
 func (ctrl *UnitController) Update(c *fiber.Ctx) error {
-	id := c.Query("id")
-	if id == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
-			Status:  "error",
-			Message: "Missing id",
-			Data:    nil,
-		})
-	}
-	var input models.Unit
-	if err := c.BodyParser(&input); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
-			Status:  "error",
-			Message: "Invalid input",
-			Data:    nil,
-		})
-	}
-	if u, err := ctrl.Repo.FindBySubDomain(c.Context(), input.SubDomain); err == nil && u.ID.Hex() != id {
-		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
-			Status:  "error",
-			Message: "sub domain exists",
-			Data:    nil,
+       var input models.Unit
+       if err := c.BodyParser(&input); err != nil {
+               return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Invalid input",
+                       Data:    nil,
+               })
+       }
+       if input.ID.IsZero() {
+               return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Missing id",
+                       Data:    nil,
+               })
+       }
+       id := input.ID.Hex()
+
+       if u, err := ctrl.Repo.FindBySubDomain(c.Context(), input.SubDomain); err == nil && u.ID.Hex() != id {
+               return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "sub domain exists",
+                       Data:    nil,
 		})
 	} else if err != nil && err != mongo.ErrNoDocuments {
 		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
@@ -167,11 +171,11 @@ func (ctrl *UnitController) Update(c *fiber.Ctx) error {
 			Data:    err.Error(),
 		})
 	}
-	if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
-			Status:  "error",
-			Message: "Failed to update unit",
-			Data:    err.Error(),
+       if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
+               return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Failed to update unit",
+                       Data:    err.Error(),
 		})
 	}
 	return c.JSON(models.APIResponse{

--- a/main.go
+++ b/main.go
@@ -24,7 +24,8 @@ func main() {
 	// Kết nối MongoDB một lần duy nhất
 	config.ConnectDB()
 
-	// Seed default admin account if needed
+	// Seed default admin unit and admin user if needed
+	seed.SeedAdminUnit()
 	seed.SeedAdminUser()
 
 	app := fiber.New()

--- a/main.go
+++ b/main.go
@@ -24,9 +24,10 @@ func main() {
 	// Kết nối MongoDB một lần duy nhất
 	config.ConnectDB()
 
-	// Seed default admin unit and admin user if needed
+	// Seed default admin unit, admin user and service account if needed
 	seed.SeedAdminUnit()
 	seed.SeedAdminUser()
+	seed.SeedAdminServiceAccount()
 
 	app := fiber.New()
 	app.Use(cors.New())

--- a/middleware/service_account.go
+++ b/middleware/service_account.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// ServiceAccount verifies the JWT belongs to an active service account.
+func ServiceAccount(repo *repositories.ServiceAccountRepository) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userToken, ok := c.Locals("user").(*jwt.Token)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Invalid token",
+				Data:    nil,
+			})
+		}
+		claims := userToken.Claims.(jwt.MapClaims)
+		id, _ := claims["id"].(string)
+		sa, err := repo.FindByID(c.Context(), id)
+		if err != nil || !sa.Active {
+			return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Unauthorized",
+				Data:    nil,
+			})
+		}
+		// attach service account to context for handlers
+		c.Locals("service_account", sa)
+		return c.Next()
+	}
+}

--- a/models/service_account.go
+++ b/models/service_account.go
@@ -1,0 +1,13 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// ServiceAccount represents an API token with associated scopes
+// for automation or third-party integrations.
+type ServiceAccount struct {
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name      string             `json:"name" bson:"name"`
+	TokenHash string             `json:"token_hash" bson:"token_hash"`
+	Scopes    []string           `json:"scopes" bson:"scopes"`
+	Active    bool               `json:"active" bson:"active"`
+}

--- a/models/service_account.go
+++ b/models/service_account.go
@@ -5,9 +5,8 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 // ServiceAccount represents an API token with associated scopes
 // for automation or third-party integrations.
 type ServiceAccount struct {
-	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name      string             `json:"name" bson:"name"`
-	TokenHash string             `json:"token_hash" bson:"token_hash"`
-	Scopes    []string           `json:"scopes" bson:"scopes"`
-	Active    bool               `json:"active" bson:"active"`
+	ID       primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name     string             `json:"name" bson:"name"`
+	Password string             `json:"password,omitempty" bson:"password"`
+	Active   bool               `json:"active" bson:"active"`
 }

--- a/models/service_account.go
+++ b/models/service_account.go
@@ -5,8 +5,10 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 // ServiceAccount represents an API token with associated scopes
 // for automation or third-party integrations.
 type ServiceAccount struct {
-	ID       primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name     string             `json:"name" bson:"name"`
-	Password string             `json:"password,omitempty" bson:"password"`
-	Active   bool               `json:"active" bson:"active"`
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Username  string             `json:"username" bson:"username"`
+	Password  string             `json:"password,omitempty" bson:"password"`
+	Name      string             `json:"name" bson:"name"`
+	UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
+	Active    bool               `json:"active" bson:"active"`
 }

--- a/models/unit.go
+++ b/models/unit.go
@@ -1,0 +1,10 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// Unit represents a single organization in a multi-tenant SaaS app.
+type Unit struct {
+	ID     primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name   string             `json:"name" bson:"name"`
+	Domain string             `json:"domain" bson:"domain"`
+}

--- a/models/unit.go
+++ b/models/unit.go
@@ -4,8 +4,9 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Unit represents a single organization in a multi-tenant SaaS app.
 type Unit struct {
-        ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-        Name      string             `json:"name" bson:"name"`
-        SubDomain string             `json:"sub_domain" bson:"sub_domain"`
-        Active    bool               `json:"active" bson:"active"`
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name      string             `json:"name" bson:"name"`
+	Logo      string             `json:"logo" bson:"logo"`
+	SubDomain string             `json:"sub_domain" bson:"sub_domain"`
+	Active    bool               `json:"active" bson:"active"`
 }

--- a/models/unit.go
+++ b/models/unit.go
@@ -4,7 +4,7 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Unit represents a single organization in a multi-tenant SaaS app.
 type Unit struct {
-	ID     primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name   string             `json:"name" bson:"name"`
-	Domain string             `json:"domain" bson:"domain"`
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name      string             `json:"name" bson:"name"`
+	SubDomain string             `json:"sub_domain" bson:"sub_domain"`
 }

--- a/models/unit.go
+++ b/models/unit.go
@@ -4,7 +4,8 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Unit represents a single organization in a multi-tenant SaaS app.
 type Unit struct {
-	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name      string             `json:"name" bson:"name"`
-	SubDomain string             `json:"sub_domain" bson:"sub_domain"`
+        ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+        Name      string             `json:"name" bson:"name"`
+        SubDomain string             `json:"sub_domain" bson:"sub_domain"`
+        Active    bool               `json:"active" bson:"active"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -4,10 +4,11 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type User struct {
-        ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-        Username  string             `json:"username" bson:"username"`
-        Password  string             `json:"password,omitempty" bson:"password"`
-        Name      string             `json:"name" bson:"name"`
-        UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
-        Active    bool               `json:"active" bson:"active"`
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Username  string             `json:"username" bson:"username"`
+	Password  string             `json:"password,omitempty" bson:"password"`
+	Name      string             `json:"name" bson:"name"`
+	UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
+	UnitID    primitive.ObjectID `json:"unit_id" bson:"unit_id"`
+	Active    bool               `json:"active" bson:"active"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -4,9 +4,10 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type User struct {
-	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Username  string             `json:"username" bson:"username"`
-	Password  string             `json:"password,omitempty" bson:"password"`
-	Name      string             `json:"name" bson:"name"`
-	UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
+        ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+        Username  string             `json:"username" bson:"username"`
+        Password  string             `json:"password,omitempty" bson:"password"`
+        Name      string             `json:"name" bson:"name"`
+        UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
+        Active    bool               `json:"active" bson:"active"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -11,4 +11,5 @@ type User struct {
 	UrlAvatar string             `json:"url_avatar" bson:"url_avatar"`
 	UnitID    primitive.ObjectID `json:"unit_id" bson:"unit_id"`
 	Active    bool               `json:"active" bson:"active"`
+	IsAdmin   bool               `json:"is_admin" bson:"is_admin"`
 }

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -45,7 +45,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\"\n}"
+              "raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\",\n  \"unit_id\": \"687f569bcd2015c348afcc27\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/login",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -169,7 +169,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Acme\",\n  \"sub_domain\": \"acme\",\n  \"active\": true\n}"
+              "raw": "{\n  \"name\": \"Acme\",\n  \"sub_domain\": \"acme\",\n  \"logo\": \"\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/units",
@@ -208,7 +208,7 @@
           "response": []
         },
         {
-          "name": "Check SubDomain",
+          "name": "Get Unit By SubDomain",
           "request": {
             "method": "GET",
             "header": [],
@@ -248,7 +248,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"sub_domain\": \"updated\",\n  \"active\": true\n}"
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"sub_domain\": \"updated\",\n  \"logo\": \"\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/units",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -169,7 +169,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Acme\",\n  \"domain\": \"acme.com\"\n}"
+              "raw": "{\n  \"name\": \"Acme\",\n  \"sub_domain\": \"acme\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/units",
@@ -214,6 +214,36 @@
           "response": []
         },
         {
+          "name": "Get Unit by SubDomain",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units/by_subdomain?sub_domain=acme",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units",
+                "by_subdomain"
+              ],
+              "query": [
+                {
+                  "key": "sub_domain",
+                  "value": "acme"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Update Unit",
           "request": {
             "method": "PUT",
@@ -229,7 +259,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated\",\n  \"domain\": \"updated.com\"\n}"
+              "raw": "{\n  \"name\": \"Updated\",\n  \"sub_domain\": \"updated\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -45,7 +45,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\",\n  \"unit_id\": \"687f569bcd2015c348afcc27\"\n}"
+              "raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\",\n  \"sub_domain\": \"admin\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/login",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -336,7 +336,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"My App\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
+              "raw": "{\n  \"username\": \"sa\",\n  \"name\": \"My App\",\n  \"url_avatar\": \"http://example.com/avatar.png\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/service_accounts",
@@ -396,7 +396,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"url_avatar\": \"http://example.com/avatar.png\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/service_accounts",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -126,6 +126,160 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Units",
+      "item": [
+        {
+          "name": "List Units",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Unit",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Acme\",\n  \"domain\": \"acme.com\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/units",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Unit",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Unit",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Updated\",\n  \"domain\": \"updated.com\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Unit",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "units"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -208,15 +208,10 @@
           "response": []
         },
         {
-          "name": "Get Unit by SubDomain",
+          "name": "Check SubDomain",
           "request": {
             "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
-              }
-            ],
+            "header": [],
             "url": {
               "raw": "{{baseUrl}}/api/units/by_subdomain?sub_domain=acme",
               "host": [

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -169,7 +169,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Acme\",\n  \"sub_domain\": \"acme\"\n}"
+              "raw": "{\n  \"name\": \"Acme\",\n  \"sub_domain\": \"acme\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/units",
@@ -195,19 +195,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",
+              "raw": "{{baseUrl}}/api/units",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "units"
-              ],
-              "query": [
-                {
-                  "key": "id",
-                  "value": "abcdef1234567890"
-                }
               ]
             }
           },
@@ -259,22 +253,16 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated\",\n  \"sub_domain\": \"updated\"\n}"
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"sub_domain\": \"updated\",\n  \"active\": true\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/api/units?id=abcdef1234567890",
+              "raw": "{{baseUrl}}/api/units",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "units"
-              ],
-              "query": [
-                {
-                  "key": "id",
-                  "value": "abcdef1234567890"
-                }
               ]
             }
           },

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -18,8 +18,6 @@
                 "exec": [
                   "pm.test(\"Login response has token and user info\", function () {\r",
                   "    var jsonData = pm.response.json();\r",
-                  "    pm.expect(jsonData.data.token).to.be.a(\"string\");\r",
-                  "    pm.expect(jsonData.data.user).to.be.an(\"object\");\r",
                   "    pm.collectionVariables.set(\"token\", jsonData.data.token);\r",
                   "});"
                 ],

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -281,5 +281,16 @@
         }
       ]
     }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "localhost:4000",
+      "type": "string"
+    },
+    {
+      "key": "token",
+      "value": ""
+    }
   ]
 }

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -336,7 +336,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"My App\",\n  \"token_hash\": \"hash\",\n  \"scopes\": [\"unit:read\"],\n  \"active\": true\n}"
+              "raw": "{\n  \"name\": \"My App\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/service_accounts",
@@ -396,7 +396,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"token_hash\": \"hash\",\n  \"scopes\": [\"unit:read\"],\n  \"active\": true\n}"
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/service_accounts",

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -293,6 +293,154 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Service Accounts",
+      "item": [
+        {
+          "name": "List Service Accounts",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Service Account",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"My App\",\n  \"token_hash\": \"hash\",\n  \"scopes\": [\"unit:read\"],\n  \"active\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Service Account",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Service Account",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"token_hash\": \"hash\",\n  \"scopes\": [\"unit:read\"],\n  \"active\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Service Account",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ],
   "variable": [

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -139,13 +139,18 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/units",
+              "raw": "{{baseUrl}}/api/units?page=1&limit=10&search=demo",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "units"
+              ],
+              "query": [
+                {"key": "page", "value": "1"},
+                {"key": "limit", "value": "10"},
+                {"key": "search", "value": "demo"}
               ]
             }
           },
@@ -295,27 +300,32 @@
     {
       "name": "Service Accounts",
       "item": [
-        {
-          "name": "List Service Accounts",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/service_accounts",
-              "host": [
-                "{{baseUrl}}"
+          {
+            "name": "List Service Accounts",
+            "request": {
+              "method": "GET",
+              "header": [
+                {
+                  "key": "Authorization",
+                  "value": "Bearer {{token}}"
+                }
               ],
-              "path": [
-                "api",
-                "service_accounts"
-              ]
-            }
-          },
+              "url": {
+                "raw": "{{baseUrl}}/api/service_accounts?page=1&limit=10&search=sa",
+                "host": [
+                  "{{baseUrl}}"
+                ],
+                "path": [
+                  "api",
+                  "service_accounts"
+                ],
+                "query": [
+                  {"key": "page", "value": "1"},
+                  {"key": "limit", "value": "10"},
+                  {"key": "search", "value": "sa"}
+                ]
+              }
+            },
           "response": []
         },
         {

--- a/repositories/unit_repository.go
+++ b/repositories/unit_repository.go
@@ -1,0 +1,81 @@
+package repositories
+
+import (
+	"context"
+	"go-fiber-api/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type UnitRepository struct {
+	collection *mongo.Collection
+}
+
+func NewUnitRepository(db *mongo.Database) *UnitRepository {
+	return &UnitRepository{collection: db.Collection("units")}
+}
+
+func (r *UnitRepository) Create(ctx context.Context, unit *models.Unit) error {
+	unit.ID = primitive.NewObjectID()
+	_, err := r.collection.InsertOne(ctx, unit)
+	return err
+}
+
+func (r *UnitRepository) GetAll(ctx context.Context, page, limit int64) ([]models.Unit, int64, error) {
+	opts := options.Find()
+	if limit > 0 {
+		opts.SetLimit(limit).SetSkip((page - 1) * limit)
+	}
+	cursor, err := r.collection.Find(ctx, bson.M{}, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var units []models.Unit
+	for cursor.Next(ctx) {
+		var t models.Unit
+		if err := cursor.Decode(&t); err != nil {
+			return nil, 0, err
+		}
+		units = append(units, t)
+	}
+	total, err := r.collection.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return nil, 0, err
+	}
+	return units, total, nil
+}
+
+func (r *UnitRepository) FindByID(ctx context.Context, id string) (*models.Unit, error) {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return nil, err
+	}
+	var unit models.Unit
+	if err := r.collection.FindOne(ctx, bson.M{"_id": objID}).Decode(&unit); err != nil {
+		return nil, err
+	}
+	return &unit, nil
+}
+
+func (r *UnitRepository) Update(ctx context.Context, id string, unit *models.Unit) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	update := bson.M{"$set": bson.M{"name": unit.Name, "domain": unit.Domain}}
+	_, err = r.collection.UpdateByID(ctx, objID, update)
+	return err
+}
+
+func (r *UnitRepository) Delete(ctx context.Context, id string) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	_, err = r.collection.DeleteOne(ctx, bson.M{"_id": objID})
+	return err
+}

--- a/repositories/unit_repository.go
+++ b/repositories/unit_repository.go
@@ -18,12 +18,12 @@ func NewUnitRepository(db *mongo.Database) *UnitRepository {
 }
 
 func (r *UnitRepository) Create(ctx context.Context, unit *models.Unit) error {
-        unit.ID = primitive.NewObjectID()
-        if !unit.Active {
-                unit.Active = true
-        }
-        _, err := r.collection.InsertOne(ctx, unit)
-        return err
+	unit.ID = primitive.NewObjectID()
+	if !unit.Active {
+		unit.Active = true
+	}
+	_, err := r.collection.InsertOne(ctx, unit)
+	return err
 }
 
 func (r *UnitRepository) GetAll(ctx context.Context, page, limit int64) ([]models.Unit, int64, error) {
@@ -74,13 +74,13 @@ func (r *UnitRepository) FindBySubDomain(ctx context.Context, subDomain string) 
 }
 
 func (r *UnitRepository) Update(ctx context.Context, id string, unit *models.Unit) error {
-        objID, err := primitive.ObjectIDFromHex(id)
-        if err != nil {
-                return err
-        }
-        update := bson.M{"$set": bson.M{"name": unit.Name, "sub_domain": unit.SubDomain, "active": unit.Active}}
-        _, err = r.collection.UpdateByID(ctx, objID, update)
-        return err
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	update := bson.M{"$set": bson.M{"name": unit.Name, "sub_domain": unit.SubDomain, "logo": unit.Logo, "active": unit.Active}}
+	_, err = r.collection.UpdateByID(ctx, objID, update)
+	return err
 }
 
 func (r *UnitRepository) Delete(ctx context.Context, id string) error {

--- a/repositories/unit_repository.go
+++ b/repositories/unit_repository.go
@@ -61,12 +61,21 @@ func (r *UnitRepository) FindByID(ctx context.Context, id string) (*models.Unit,
 	return &unit, nil
 }
 
+func (r *UnitRepository) FindBySubDomain(ctx context.Context, subDomain string) (*models.Unit, error) {
+	var unit models.Unit
+	err := r.collection.FindOne(ctx, bson.M{"sub_domain": subDomain}).Decode(&unit)
+	if err != nil {
+		return nil, err
+	}
+	return &unit, nil
+}
+
 func (r *UnitRepository) Update(ctx context.Context, id string, unit *models.Unit) error {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return err
 	}
-	update := bson.M{"$set": bson.M{"name": unit.Name, "domain": unit.Domain}}
+	update := bson.M{"$set": bson.M{"name": unit.Name, "sub_domain": unit.SubDomain}}
 	_, err = r.collection.UpdateByID(ctx, objID, update)
 	return err
 }

--- a/repositories/unit_repository.go
+++ b/repositories/unit_repository.go
@@ -18,9 +18,12 @@ func NewUnitRepository(db *mongo.Database) *UnitRepository {
 }
 
 func (r *UnitRepository) Create(ctx context.Context, unit *models.Unit) error {
-	unit.ID = primitive.NewObjectID()
-	_, err := r.collection.InsertOne(ctx, unit)
-	return err
+        unit.ID = primitive.NewObjectID()
+        if !unit.Active {
+                unit.Active = true
+        }
+        _, err := r.collection.InsertOne(ctx, unit)
+        return err
 }
 
 func (r *UnitRepository) GetAll(ctx context.Context, page, limit int64) ([]models.Unit, int64, error) {
@@ -71,13 +74,13 @@ func (r *UnitRepository) FindBySubDomain(ctx context.Context, subDomain string) 
 }
 
 func (r *UnitRepository) Update(ctx context.Context, id string, unit *models.Unit) error {
-	objID, err := primitive.ObjectIDFromHex(id)
-	if err != nil {
-		return err
-	}
-	update := bson.M{"$set": bson.M{"name": unit.Name, "sub_domain": unit.SubDomain}}
-	_, err = r.collection.UpdateByID(ctx, objID, update)
-	return err
+        objID, err := primitive.ObjectIDFromHex(id)
+        if err != nil {
+                return err
+        }
+        update := bson.M{"$set": bson.M{"name": unit.Name, "sub_domain": unit.SubDomain, "active": unit.Active}}
+        _, err = r.collection.UpdateByID(ctx, objID, update)
+        return err
 }
 
 func (r *UnitRepository) Delete(ctx context.Context, id string) error {

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -33,9 +33,12 @@ func (r *UserRepository) FindByUsername(ctx context.Context, username string) (*
 
 // Tạo user mới
 func (r *UserRepository) Create(ctx context.Context, user *models.User) error {
-	user.ID = primitive.NewObjectID()
-	_, err := r.collection.InsertOne(ctx, user)
-	return err
+        user.ID = primitive.NewObjectID()
+        if !user.Active {
+                user.Active = true
+        }
+        _, err := r.collection.InsertOne(ctx, user)
+        return err
 }
 
 // Kiểm tra username đã tồn tại

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -27,6 +27,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	units := api.Group("/units")
 	units.Get("", unitCtrl.List)
 	units.Post("", unitCtrl.Create)
+	units.Get("/by_subdomain", unitCtrl.GetBySubDomain)
 	units.Put("", unitCtrl.Update)
 	units.Delete("", unitCtrl.Delete)
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,6 +13,8 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	// Initialize repositories and controllers once so they can be reused
 	userRepo := repositories.NewUserRepository(db)
 	authCtrl := controllers.NewAuthController(userRepo)
+	unitRepo := repositories.NewUnitRepository(db)
+	unitCtrl := controllers.NewUnitController(unitRepo)
 
 	// Public routes do not require authentication
 	app.Post("/login", authCtrl.Login)
@@ -21,4 +23,10 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	api := app.Group("/api", middleware.Protected())
 	api.Put("/presigned_url", controllers.GetUploadUrl)
 	api.Delete("/image", controllers.DeleteImage)
+
+	units := api.Group("/units")
+	units.Get("", unitCtrl.List)
+	units.Post("", unitCtrl.Create)
+	units.Put("", unitCtrl.Update)
+	units.Delete("", unitCtrl.Delete)
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -14,7 +14,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	userRepo := repositories.NewUserRepository(db)
 	unitRepo := repositories.NewUnitRepository(db)
 	saRepo := repositories.NewServiceAccountRepository(db)
-	authCtrl := controllers.NewAuthController(userRepo, unitRepo)
+	authCtrl := controllers.NewAuthController(userRepo, unitRepo, saRepo)
 	unitCtrl := controllers.NewUnitController(unitRepo)
 	saCtrl := controllers.NewServiceAccountController(saRepo)
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,8 +13,10 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	// Initialize repositories and controllers once so they can be reused
 	userRepo := repositories.NewUserRepository(db)
 	unitRepo := repositories.NewUnitRepository(db)
+	saRepo := repositories.NewServiceAccountRepository(db)
 	authCtrl := controllers.NewAuthController(userRepo, unitRepo)
 	unitCtrl := controllers.NewUnitController(unitRepo)
+	saCtrl := controllers.NewServiceAccountController(saRepo)
 
 	// Public routes do not require authentication
 	app.Post("/login", authCtrl.Login)
@@ -30,4 +32,10 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	units.Post("", unitCtrl.Create)
 	units.Put("", unitCtrl.Update)
 	units.Delete("", unitCtrl.Delete)
+
+	sas := api.Group("/service_accounts")
+	sas.Get("", saCtrl.List)
+	sas.Post("", saCtrl.Create)
+	sas.Put("", saCtrl.Update)
+	sas.Delete("", saCtrl.Delete)
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -33,7 +33,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	units.Put("", unitCtrl.Update)
 	units.Delete("", unitCtrl.Delete)
 
-	sas := api.Group("/service_accounts")
+	sas := api.Group("/service_accounts", middleware.ServiceAccount(saRepo))
 	sas.Get("", saCtrl.List)
 	sas.Post("", saCtrl.Create)
 	sas.Put("", saCtrl.Update)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -18,6 +18,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 
 	// Public routes do not require authentication
 	app.Post("/login", authCtrl.Login)
+	app.Get("/api/units/by_subdomain", unitCtrl.GetBySubDomain)
 
 	// Protected API group requires JWT authentication
 	api := app.Group("/api", middleware.Protected())
@@ -27,7 +28,6 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	units := api.Group("/units")
 	units.Get("", unitCtrl.List)
 	units.Post("", unitCtrl.Create)
-	units.Get("/by_subdomain", unitCtrl.GetBySubDomain)
 	units.Put("", unitCtrl.Update)
 	units.Delete("", unitCtrl.Delete)
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -12,8 +12,8 @@ import (
 func Setup(app *fiber.App, db *mongo.Database) {
 	// Initialize repositories and controllers once so they can be reused
 	userRepo := repositories.NewUserRepository(db)
-	authCtrl := controllers.NewAuthController(userRepo)
 	unitRepo := repositories.NewUnitRepository(db)
+	authCtrl := controllers.NewAuthController(userRepo, unitRepo)
 	unitCtrl := controllers.NewUnitController(unitRepo)
 
 	// Public routes do not require authentication

--- a/seed/service_account.go
+++ b/seed/service_account.go
@@ -1,0 +1,35 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+
+	"go-fiber-api/config"
+	"go-fiber-api/models"
+	"go-fiber-api/utils"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// SeedAdminServiceAccount creates an initial admin service account if one doesn't exist.
+func SeedAdminServiceAccount() {
+	collection := config.DB.Collection("service_accounts")
+	var existing models.ServiceAccount
+	err := collection.FindOne(context.TODO(), bson.M{"name": "admin"}).Decode(&existing)
+	if err != mongo.ErrNoDocuments {
+		fmt.Println("✅ Admin service account already exists.")
+		return
+	}
+	password, _ := utils.HashPassword("admin123")
+	sa := models.ServiceAccount{
+		Name:     "admin",
+		Password: password,
+		Active:   true,
+	}
+	if _, err := collection.InsertOne(context.TODO(), sa); err != nil {
+		fmt.Println("❌ Failed to seed admin service account:", err)
+		return
+	}
+	fmt.Println("🚀 Admin service account seeded successfully: name=admin password=admin123")
+}

--- a/seed/service_account.go
+++ b/seed/service_account.go
@@ -16,20 +16,22 @@ import (
 func SeedAdminServiceAccount() {
 	collection := config.DB.Collection("service_accounts")
 	var existing models.ServiceAccount
-       err := collection.FindOne(context.TODO(), bson.M{"name": "sa"}).Decode(&existing)
+	err := collection.FindOne(context.TODO(), bson.M{"username": "sa"}).Decode(&existing)
 	if err != mongo.ErrNoDocuments {
 		fmt.Println("✅ Admin service account already exists.")
 		return
 	}
-       password, _ := utils.HashPassword("sa123")
-       sa := models.ServiceAccount{
-               Name:     "sa",
-               Password: password,
-               Active:   true,
-       }
+	password, _ := utils.HashPassword("sa123")
+	sa := models.ServiceAccount{
+		Username:  "sa",
+		Name:      "sa",
+		UrlAvatar: "",
+		Password:  password,
+		Active:    true,
+	}
 	if _, err := collection.InsertOne(context.TODO(), sa); err != nil {
 		fmt.Println("❌ Failed to seed admin service account:", err)
 		return
 	}
-       fmt.Println("🚀 Admin service account seeded successfully: name=sa password=sa123")
+	fmt.Println("🚀 Admin service account seeded successfully: name=sa password=sa123")
 }

--- a/seed/service_account.go
+++ b/seed/service_account.go
@@ -16,20 +16,20 @@ import (
 func SeedAdminServiceAccount() {
 	collection := config.DB.Collection("service_accounts")
 	var existing models.ServiceAccount
-	err := collection.FindOne(context.TODO(), bson.M{"name": "admin"}).Decode(&existing)
+       err := collection.FindOne(context.TODO(), bson.M{"name": "sa"}).Decode(&existing)
 	if err != mongo.ErrNoDocuments {
 		fmt.Println("✅ Admin service account already exists.")
 		return
 	}
-	password, _ := utils.HashPassword("admin123")
-	sa := models.ServiceAccount{
-		Name:     "admin",
-		Password: password,
-		Active:   true,
-	}
+       password, _ := utils.HashPassword("sa123")
+       sa := models.ServiceAccount{
+               Name:     "sa",
+               Password: password,
+               Active:   true,
+       }
 	if _, err := collection.InsertOne(context.TODO(), sa); err != nil {
 		fmt.Println("❌ Failed to seed admin service account:", err)
 		return
 	}
-	fmt.Println("🚀 Admin service account seeded successfully: name=admin password=admin123")
+       fmt.Println("🚀 Admin service account seeded successfully: name=sa password=sa123")
 }

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -26,6 +26,7 @@ func SeedAdminUnit() {
 	unit := models.Unit{
 		ID:        id,
 		Name:      "Admin",
+		Logo:      "",
 		SubDomain: "admin",
 		Active:    true,
 	}

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -1,0 +1,37 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+
+	"go-fiber-api/config"
+	"go-fiber-api/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// SeedAdminUnit ensures a default admin unit exists.
+func SeedAdminUnit() {
+	collection := config.DB.Collection("units")
+	var existing models.Unit
+	id, _ := primitive.ObjectIDFromHex("687f569bcd2015c348afcc27")
+	err := collection.FindOne(context.TODO(), bson.M{"_id": id}).Decode(&existing)
+	if err != mongo.ErrNoDocuments {
+		fmt.Println("✅ Admin unit already exists.")
+		return
+	}
+	// ensure we use the same ID as specified
+	unit := models.Unit{
+		ID:        id,
+		Name:      "Admin",
+		SubDomain: "admin",
+		Active:    true,
+	}
+	if _, err := collection.InsertOne(context.TODO(), unit); err != nil {
+		fmt.Println("❌ Failed to seed admin unit:", err)
+		return
+	}
+	fmt.Println("🚀 Admin unit seeded successfully")
+}

--- a/seed/unit.go
+++ b/seed/unit.go
@@ -23,13 +23,13 @@ func SeedAdminUnit() {
 		return
 	}
 	// ensure we use the same ID as specified
-	unit := models.Unit{
-		ID:        id,
-		Name:      "Admin",
-		Logo:      "",
-		SubDomain: "admin",
-		Active:    true,
-	}
+       unit := models.Unit{
+               ID:        id,
+               Name:      "default units",
+               Logo:      "",
+               SubDomain: "unti1",
+               Active:    true,
+       }
 	if _, err := collection.InsertOne(context.TODO(), unit); err != nil {
 		fmt.Println("❌ Failed to seed admin unit:", err)
 		return

--- a/seed/user.go
+++ b/seed/user.go
@@ -20,12 +20,13 @@ func SeedAdminUser() {
 		return
 	}
 	password, _ := utils.HashPassword("admin123")
-	admin := models.User{
-		Username:  "admin",
-		Password:  password,
-		Name:      "Administrator",
-		UrlAvatar: "",
-	}
+       admin := models.User{
+               Username:  "admin",
+               Password:  password,
+               Name:      "Administrator",
+               UrlAvatar: "",
+               Active:    true,
+       }
 
 	_, err = collection.InsertOne(context.TODO(), admin)
 	if err != nil {

--- a/seed/user.go
+++ b/seed/user.go
@@ -8,6 +8,7 @@ import (
 	"go-fiber-api/utils"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -20,13 +21,15 @@ func SeedAdminUser() {
 		return
 	}
 	password, _ := utils.HashPassword("admin123")
-       admin := models.User{
-               Username:  "admin",
-               Password:  password,
-               Name:      "Administrator",
-               UrlAvatar: "",
-               Active:    true,
-       }
+	unitID, _ := primitive.ObjectIDFromHex("687f569bcd2015c348afcc27")
+	admin := models.User{
+		Username:  "admin",
+		Password:  password,
+		Name:      "Administrator",
+		UrlAvatar: "",
+		Active:    true,
+		UnitID:    unitID,
+	}
 
 	_, err = collection.InsertOne(context.TODO(), admin)
 	if err != nil {

--- a/seed/user.go
+++ b/seed/user.go
@@ -29,6 +29,7 @@ func SeedAdminUser() {
 		UrlAvatar: "",
 		Active:    true,
 		UnitID:    unitID,
+		IsAdmin:   true,
 	}
 
 	_, err = collection.InsertOne(context.TODO(), admin)


### PR DESCRIPTION
## Summary
- support single unit retrieval, update and delete via `?id` query param
- adjust routes for units endpoints
- update Postman collection to demonstrate new query usage

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_687f4d0afdcc8326b96c4cd63a294bcd