### PR TITLE
Implement user management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ The response includes the user's `unit_id` and an `is_admin` flag. If you pass
 accounts instead of regular users. A default admin service account is seeded
 with name `sa` and password `sa123`.
 
-Both the unit and service-account list endpoints support optional search and
+The unit, service-account and user list endpoints support optional search and
 pagination:
 
 ```
 GET /api/units?page=1&limit=20&search=demo
 GET /api/service_accounts?page=1&limit=20&search=sa
+GET /api/users?page=1&limit=20&search=admin
 ```
 
 If `page` or `limit` are omitted the full list is returned.

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,0 +1,211 @@
+package controllers
+
+import (
+	"errors"
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+	"go-fiber-api/utils"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// UserController handles user CRUD operations.
+type UserController struct {
+	Repo *repositories.UserRepository
+}
+
+// NewUserController creates a new controller instance.
+func NewUserController(repo *repositories.UserRepository) *UserController {
+	return &UserController{Repo: repo}
+}
+
+// Create adds a new user under the admin's unit.
+func (ctrl *UserController) Create(c *fiber.Ctx) error {
+	var input models.User
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if exists, err := ctrl.Repo.IsUsernameExists(c.Context(), input.Username); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to create user",
+			Data:    err.Error(),
+		})
+	} else if exists {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "username exists",
+			Data:    nil,
+		})
+	}
+	admin := c.Locals("admin_user").(*models.User)
+	input.UnitID = admin.UnitID
+	if input.Password != "" {
+		hashed, _ := utils.HashPassword(input.Password)
+		input.Password = hashed
+	}
+	if err := ctrl.Repo.Create(c.Context(), &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to create user",
+			Data:    err.Error(),
+		})
+	}
+	input.Password = ""
+	return c.Status(fiber.StatusCreated).JSON(models.APIResponse{
+		Status:  "success",
+		Message: "User created",
+		Data:    input,
+	})
+}
+
+// List returns users belonging to the admin's unit.
+func (ctrl *UserController) List(c *fiber.Ctx) error {
+	admin := c.Locals("admin_user").(*models.User)
+	if id := c.Query("id"); id != "" {
+		user, err := ctrl.Repo.FindByID(c.Context(), id)
+		if err != nil || user.UnitID != admin.UnitID {
+			if errors.Is(err, repositories.ErrNotFound) {
+				return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+					Status:  "error",
+					Message: "User not found",
+					Data:    nil,
+				})
+			}
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "User not found",
+				Data:    nil,
+			})
+		}
+		user.Password = ""
+		return c.JSON(models.APIResponse{
+			Status:  "success",
+			Message: "User retrieved",
+			Data:    user,
+		})
+	}
+	search := c.Query("search")
+	page := c.QueryInt("page", 0)
+	limit := c.QueryInt("limit", 0)
+	users, total, err := ctrl.Repo.GetAllByUnit(c.Context(), admin.UnitID, search, int64(page), int64(limit))
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to list users",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Users retrieved",
+		Data: fiber.Map{
+			"items": users,
+			"total": total,
+		},
+	})
+}
+
+// Update modifies an existing user within the admin's unit.
+func (ctrl *UserController) Update(c *fiber.Ctx) error {
+	var input models.User
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid input",
+			Data:    nil,
+		})
+	}
+	if input.ID.IsZero() {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	admin := c.Locals("admin_user").(*models.User)
+	id := input.ID.Hex()
+	user, err := ctrl.Repo.FindByID(c.Context(), id)
+	if err != nil || user.UnitID != admin.UnitID {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "User not found",
+				Data:    nil,
+			})
+		}
+		return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "User not found",
+			Data:    nil,
+		})
+	}
+	if input.Password != "" {
+		hashed, _ := utils.HashPassword(input.Password)
+		input.Password = hashed
+	}
+	if err := ctrl.Repo.Update(c.Context(), id, &input); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to update user",
+			Data:    err.Error(),
+		})
+	}
+	input.Password = ""
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "User updated",
+		Data:    input,
+	})
+}
+
+// Delete removes a user from the admin's unit.
+func (ctrl *UserController) Delete(c *fiber.Ctx) error {
+	admin := c.Locals("admin_user").(*models.User)
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+	user, err := ctrl.Repo.FindByID(c.Context(), id)
+	if err != nil || user.UnitID != admin.UnitID {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "User not found",
+				Data:    nil,
+			})
+		}
+		return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "User not found",
+			Data:    nil,
+		})
+	}
+	if err := ctrl.Repo.Delete(c.Context(), id); err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "User not found",
+				Data:    nil,
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Failed to delete user",
+			Data:    err.Error(),
+		})
+	}
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "User deleted",
+		Data:    nil,
+	})
+}

--- a/middleware/admin_user.go
+++ b/middleware/admin_user.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// AdminUser verifies the JWT belongs to an active admin user.
+func AdminUser(repo *repositories.UserRepository) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userToken, ok := c.Locals("user").(*jwt.Token)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Invalid token",
+				Data:    nil,
+			})
+		}
+		claims := userToken.Claims.(jwt.MapClaims)
+		id, _ := claims["id"].(string)
+		user, err := repo.FindByID(c.Context(), id)
+		if err != nil || !user.Active || !user.IsAdmin {
+			return c.Status(fiber.StatusUnauthorized).JSON(models.APIResponse{
+				Status:  "error",
+				Message: "Unauthorized",
+				Data:    nil,
+			})
+		}
+		// attach user to context
+		c.Locals("admin_user", user)
+		return c.Next()
+	}
+}

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -148,9 +148,18 @@
                 "units"
               ],
               "query": [
-                {"key": "page", "value": "1"},
-                {"key": "limit", "value": "10"},
-                {"key": "search", "value": "demo"}
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "search",
+                  "value": "demo"
+                }
               ]
             }
           },
@@ -300,32 +309,41 @@
     {
       "name": "Service Accounts",
       "item": [
-          {
-            "name": "List Service Accounts",
-            "request": {
-              "method": "GET",
-              "header": [
-                {
-                  "key": "Authorization",
-                  "value": "Bearer {{token}}"
-                }
-              ],
-              "url": {
-                "raw": "{{baseUrl}}/api/service_accounts?page=1&limit=10&search=sa",
-                "host": [
-                  "{{baseUrl}}"
-                ],
-                "path": [
-                  "api",
-                  "service_accounts"
-                ],
-                "query": [
-                  {"key": "page", "value": "1"},
-                  {"key": "limit", "value": "10"},
-                  {"key": "search", "value": "sa"}
-                ]
+        {
+          "name": "List Service Accounts",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
               }
-            },
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/service_accounts?page=1&limit=10&search=sa",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "service_accounts"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "search",
+                  "value": "sa"
+                }
+              ]
+            }
+          },
           "response": []
         },
         {
@@ -437,6 +455,168 @@
               "path": [
                 "api",
                 "service_accounts"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "List Users",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/users?page=1&limit=10&search=demo",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "search",
+                  "value": "demo"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"user\",\n  \"name\": \"New User\",\n  \"password\": \"secret\",\n  \"url_avatar\": \"http://example.com/avatar.png\",\n  \"active\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get User",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/users?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "abcdef1234567890"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"abcdef1234567890\",\n  \"name\": \"Updated\",\n  \"url_avatar\": \"http://example.com/avatar.png\",\n  \"password\": \"secret\",\n  \"active\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/users?id=abcdef1234567890",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
               ],
               "query": [
                 {

--- a/repositories/errors.go
+++ b/repositories/errors.go
@@ -1,0 +1,5 @@
+package repositories
+
+import "errors"
+
+var ErrNotFound = errors.New("not found")

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,6 +17,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	authCtrl := controllers.NewAuthController(userRepo, unitRepo, saRepo)
 	unitCtrl := controllers.NewUnitController(unitRepo)
 	saCtrl := controllers.NewServiceAccountController(saRepo)
+	userCtrl := controllers.NewUserController(userRepo)
 
 	// Public routes do not require authentication
 	app.Post("/login", authCtrl.Login)
@@ -32,6 +33,12 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	units.Post("", unitCtrl.Create)
 	units.Put("", unitCtrl.Update)
 	units.Delete("", unitCtrl.Delete)
+
+	users := api.Group("/users", middleware.AdminUser(userRepo))
+	users.Get("", userCtrl.List)
+	users.Post("", userCtrl.Create)
+	users.Put("", userCtrl.Update)
+	users.Delete("", userCtrl.Delete)
 
 	sas := api.Group("/service_accounts", middleware.ServiceAccount(saRepo))
 	sas.Get("", saCtrl.List)


### PR DESCRIPTION
## Summary
- add middleware to validate admin users
- implement user CRUD controller
- extend user repository for update, delete and listing by unit
- expose `/api/users` routes
- document new endpoints and update Postman collection
- refactor user controller to rely on repository error handling

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6881dfde9f488326992a35773cada970